### PR TITLE
Allow item search with multiple item ids

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ var generateQueryString = function(query, method, credentials) {
   } else if (method === 'ItemLookup') {
     var idType = query.idType || 'ASIN';
     var includeReviewsSummary = query.includeReviewsSummary || 'True';
-    var itemId = query.itemId;
+    var itemId = query.itemId.replace(/,/g, '%2C');
     var truncateReviewsAt = query.truncateReviewsAt || '1000';
     var variationPage = query.variationPage || 'All';
     searchIndex = (idType ==='ASIN') ? '' : '&SearchIndex='+ searchIndex;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ var generateQueryString = function(query, method, credentials) {
   } else if (method === 'ItemLookup') {
     var idType = query.idType || 'ASIN';
     var includeReviewsSummary = query.includeReviewsSummary || 'True';
-    var itemId = query.itemId.replace(/,/g, '%2C');
+    var itemId = encodeURIComponent(query.itemId);
     var truncateReviewsAt = query.truncateReviewsAt || '1000';
     var variationPage = query.variationPage || 'All';
     searchIndex = (idType ==='ASIN') ? '' : '&SearchIndex='+ searchIndex;


### PR DESCRIPTION
I have been doing similarity searches which return up to five itemids.  I would like to look up all five ids in one call passing in a comma-separted list of ids.  If the commas are not escaped I get a cryptic error message from Amazon.