### PR TITLE
ItemLookUp fails if SearchIndex is present and itemTypeId is ASIN

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,7 +54,6 @@ var formatQueryParams = function (query, method, credentials) {
   } else if (method === 'ItemLookup') {
     // Default
     params = setDefaultParams(params, {
-      SearchIndex: 'All',
       Condition: 'All',
       ResponseGroup: 'ItemAttributes',
       IdType: 'ASIN',


### PR DESCRIPTION
Item look up fails when searching by ASIN. SeachIndex param should not be present when searching by ASIN. Fix is to remove SeachIndex param from the default params for ItemLookup.