### PR TITLE
fix double request when using callbacks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ var runQuery = function (credentials, method) {
           });
         }
       });
-
+      return;
     }
 
     var promise = new Promise(function (resolve, reject) {


### PR DESCRIPTION
An extra duplicate API request is sent when using this module "callback" style: 1 for the callback, 1 for the promise.