### PR TITLE
Return Product API Errors from the Request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,7 @@ var generateQueryString = require('./utils').generateQueryString,
 var runQuery = function (credentials, method) {
 
   return function (query, cb) {
-    var url = generateQueryString(query, method, credentials),
-      results;
+    var url = generateQueryString(query, method, credentials);
 
     if (typeof cb === 'function') {
       request(url, function (err, response, body) {
@@ -29,12 +28,18 @@ var runQuery = function (credentials, method) {
             if (err) {
               cb(err);
             } else {
-              if (method === 'BrowseNodeLookup' && resp[method + 'Response'].BrowseNodes && resp[method + 'Response'].BrowseNodes.length > 0) {
-                results = resp[method + 'Response'].BrowseNodes[0].BrowseNode;
+              var results = null;
+              var responseObject = resp[method + 'Response'];
+              if (method === 'BrowseNodeLookup' && responseObject.BrowseNodes && responseObject.BrowseNodes.length > 0) {
+                results = responseObject.BrowseNodes[0].BrowseNode;
               } else {
-                results = resp[method + 'Response'].Items[0].Item;
+                results = responseObject.Items[0].Item;
               }
-              cb(null, results);
+              if (responseObject.Items[0].Request[0].Errors) {
+                cb(responseObject.Items[0].Request[0].Errors, results);
+              } else {
+                cb(null, results);
+              }
             }
           });
         }
@@ -65,7 +70,9 @@ var runQuery = function (credentials, method) {
             } else {
               var results = null;
               var responseObject = resp[method + 'Response'];
-              if (responseObject.Items && responseObject.Items.length > 0) {
+              if (responseObject.Items[0].Request[0].Errors) {
+                reject(responseObject.Items[0].Request[0].Errors);
+              } else if (responseObject.Items && responseObject.Items.length > 0) {
                 results = responseObject.Items[0].Item;
               } else if (responseObject.BrowseNodes && responseObject.BrowseNodes.length > 0) {
                 results = responseObject.BrowseNodes[0].BrowseNode;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-product-api",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Amazon Product Advertising API client",
   "main": "./lib/index.js",
   "directories": {

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -187,6 +187,24 @@ describe 'client.itemLookup(query, cb)', ->
           err.should.have.property 'Error'
           done()
 
+
+  describe 'when the request returns an error', ->
+    client = amazonProductApi.createClient credentials
+
+    describe 'when no callback is passed', ->
+      it 'should return the errors inside the request node', ->
+        client.itemLookup
+          idType: 'ASIN',
+          itemId: 'B00QTDTUVM'
+        .catch (err) ->
+          err.should.be.an.Array
+
+    describe 'when callback is passed', ->
+      it 'should return the errors inside the request node', ->
+        client.itemLookup {idType: 'ASIN', itemId: 'B00QTDTUVM'}, (err, results) ->
+          err.should.be.an.Array
+          results.should.be.an.Array
+
 describe 'client.browseNodeLookup(query, cb)', ->
 
   describe 'when credentials are valid', ->


### PR DESCRIPTION
Hi there!

I was annoyed that I wasn't getting errors from the API as they are shown at the [Product API Scratchpad](http://associates-amazon.s3.amazonaws.com/scratchpad/index.html) and added a few lines so the module can return these and know exactly what happened (now you can only see there are no Items in the result).

So API errors inside the `Request` node like this one:

```xml
<Errors>
  <Error>
    <Code>AWS.ECommerceService.ItemNotAccessible</Code>
    <Message>This item is not accessible through the Product Advertising API.</Message>
  </Error>
</Errors>
```

Are being returned as errors in the callback/promise methods in JSON:

```javascript
[{
  "Error":
    [{
      "Code": ["AWS.ECommerceService.ItemNotAccessible"],
      "Message": ["This item is not accessible through the Product Advertising API."]
    }]
}]
```

Let me know if there's anything wrong with this or missing.