### PR TITLE
Update API version for ItemLookup to 2013-08-01

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ var capitalize = function (string) {
 
 var setDefaultParams = function (params, defaultParams) {
   for (param in defaultParams) {
-    if (typeof params[param] == "undefined") {
+    if (typeof params[param] === 'undefined') {
       params[param] = defaultParams[param];
     }
   }
@@ -65,12 +65,12 @@ var formatQueryParams = function (query, method, credentials) {
 
     // Constraints
     // If ItemId is an ASIN (specified by IdType), a search index cannot be specified in the request.
-    if (params['IdType'] == 'ASIN') {
+    if (params['IdType'] === 'ASIN') {
       delete params['SearchIndex'];
     }
 
     // Constants
-    params['Version'] = '2011-08-01';
+    params['Version'] = '2013-08-01';
 
   } else if (method === 'BrowseNodeLookup') {
     // Default
@@ -80,7 +80,7 @@ var formatQueryParams = function (query, method, credentials) {
     });
   }
 
-  // Common params  
+  // Common params
   params['AWSAccessKeyId'] = credentials.awsId;
   params['AssociateTag'] = credentials.awsTag;
   params['Timestamp'] = new Date().toISOString();


### PR DESCRIPTION
Changed API version from 2011-08-01 to 2013-08-01 when using the ItemLookup method as discussed in #26. All tests are passing OK.

You may want to update the dependencies (the badge is showing yellow at the moment) and bump the package version to NPM afterwards.

Thanks!