### PR TITLE
Fix for strict mode.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ var capitalize = function (string) {
 }
 
 var setDefaultParams = function (params, defaultParams) {
-  for (param in defaultParams) {
+  for (var param in defaultParams) {
     if (typeof params[param] === 'undefined') {
       params[param] = defaultParams[param];
     }
@@ -33,7 +33,7 @@ var formatQueryParams = function (query, method, credentials) {
   var params = {};
 
   // format query keys
-  for (param in query) {
+  for (var param in query) {
     var capitalized = capitalize(param);
     params[capitalized] = query[param];
   }


### PR DESCRIPTION
 Omitting "var" in a "for loop" throws "ReferenceError: ... is not defined" in strict mode.