### PR TITLE
Fix BrowseNodeLookup callback example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ client.browseNodeLookup({
 
 using a callback:
 ```javascript
-client.itemLookup({
+client.browseNodeLookup({
   browseNodeId: '549726',
   responseGroup: 'NewReleases'
 }, function(err, results) {


### PR DESCRIPTION
The example was calling `itemLookup` instead of `browseNodeLookup`, probably because of copying and pasting. This PR fixes the example with callbacks.