### PR TITLE
Support error handling for browsenodelookup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var generateQueryString = require('./utils').generateQueryString,
-  request = require('request'),
-  parseXML = require('xml2js').parseString,
-  Promise = require('es6-promise').Promise;
+    request = require('request'),
+    parseXML = require('xml2js').parseString,
+    Promise = require('es6-promise').Promise;
 
 var runQuery = function (credentials, method) {
 
@@ -38,6 +38,8 @@ var runQuery = function (credentials, method) {
                 }
               } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0 && respObj.BrowseNodes[0].BrowseNode) {
                 cb(null, respObj.BrowseNodes[0].BrowseNode);
+              } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0 && respObj.BrowseNodes[0].Request && respObj.BrowseNodes[0].Request[0].Errors && respObj.BrowseNodes[0].Request[0].Errors.length > 0 ) {
+                cb(respObj.BrowseNodes[0].Request[0].Errors && respObj.BrowseNodes[0].Request[0].Errors[0].Error);
               }
             }
           });

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,9 @@ var runQuery = function (credentials, method) {
                 }
               } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0 && respObj.BrowseNodes[0].BrowseNode) {
                 resolve(respObj.BrowseNodes[0].BrowseNode);
+              } else {
+                // Unknown situation, return as an error
+                resolve(respObj);
               }
             }
           });


### PR DESCRIPTION
I was trying to do a browseNodeLookup with incorrect response groups, no error was returned. Added this and also included a error callback for unknown responses.

`amazon_client.browseNodeLookup({
                    browseNodeId: 12345,
                    responseGroup: ['TopSellers', 'Images', 'ItemAttributes', 'OfferSummary'],
                    domain: api_domain
                }, function(err, products) {
                    if (err) {
                        callback(err, null);
                    } else {
                        return callback(null, products);
                    }
                });`