### PR TITLE
Adds error handling to browse node lookups, similar to those for items.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,12 +40,17 @@ var runQuery = function (credentials, method) {
                     respObj.Items[0]
                   );
                 }
-              } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0 && respObj.BrowseNodes[0].BrowseNode) {
-                cb(
-                  null,
-                  respObj.BrowseNodes[0].BrowseNode,
-                  respObj.BrowseNodes[0]
-                );
+              } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0) {
+                // Request Error
+                if (respObj.BrowseNodes[0].Request && respObj.BrowseNodes[0].Request.length > 0 && respObj.BrowseNodes[0].Request[0].Errors) {
+                  cb(respObj.BrowseNodes[0].Request[0].Errors);
+                } else if (respObj.BrowseNodes[0].BrowseNode) {
+                  cb(
+                    null,
+                    respObj.BrowseNodes[0].BrowseNode,
+                    respObj.BrowseNodes[0]
+                  );
+                }
               }
             }
           });
@@ -83,8 +88,13 @@ var runQuery = function (credentials, method) {
                 } else if (respObj.Items[0].Item) {
                   resolve(respObj.Items[0].Item);
                 }
-              } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0 && respObj.BrowseNodes[0].BrowseNode) {
+              } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0) {
+                // Request Error
+                if (respObj.BrowseNodes[0].Request && respObj.BrowseNodes[0].Request.length > 0 && respObj.BrowseNodes[0].Request[0].Errors) {
+                  reject(respObj.BrowseNodes[0].Request[0].Errors);
+                } else if (respObj.BrowseNodes[0].BrowseNode) {
                   resolve(respObj.BrowseNodes[0].BrowseNode);
+                }
               }
             }
           });

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -251,3 +251,24 @@ describe 'client.browseNodeLookup(query, cb)', ->
           err.should.be.an.Object
           err.should.have.property 'Error'
           done()
+
+  describe 'when the request returns an error', ->
+    client = amazonProductApi.createClient credentials
+
+    describe 'when no callback is passed', ->
+      it 'should return the errors inside the request node', ->
+        client.browseNodeLookup
+          browseNodeId: '102340',
+          responseGroup: 'NewReleases'
+        .catch (err) =>
+          err.should.be.an.Array
+          err[0].should.be.an.Object
+          err[0].should.have.property 'Error'
+
+    describe 'when callback is passed', ->
+      it 'should return the errors inside the request node', ->
+        client.browseNodeLookup {browseNodeId: '102340', responseGroup: 'NewReleases'}, (err, results) ->
+          err.should.be.an.Array
+          err[0].should.be.an.Object
+          err[0].should.have.property 'Error'
+          done()


### PR DESCRIPTION
 * aligns the error handling for browse node lookups with that of item lookups
   and searches
 * adds two tests for an invalid browse node