### PR TITLE
Encode reserved characters of RFC 3986

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,7 +100,9 @@ var generateQueryString = function (query, method, credentials) {
 
   // generate query
   unsignedString = Object.keys(params).map(function (key) {
-    return key + "=" + encodeURIComponent(params[key]);
+    return key + "=" + encodeURIComponent(params[key]).replace(/[!'()*]/g, function(c) {
+      return '%' + c.charCodeAt(0).toString(16);
+    });
   }).join("&")
 
   var signature = encodeURIComponent(generateSignature('GET\n' + domain + '\n/onca/xml\n' + unsignedString, credentials.awsSecret)).replace(/\+/g, '%2B');

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -271,4 +271,14 @@ describe 'client.browseNodeLookup(query, cb)', ->
           err.should.be.an.Array
           err[0].should.be.an.Object
           err[0].should.have.property 'Error'
-          done()
+
+  describe 'escape rfc 3986 reserved chars', ->
+    client = amazonProductApi.createClient credentials
+
+    it 'should return search results from amazon', ->
+      client.itemSearch
+        keywords: "Ender's Game"
+        searchIndex: 'DVD'
+        responseGroup: 'Offers'
+      .then (results) ->
+        results.should.be.an.Array


### PR DESCRIPTION
Without comply with RFC 3986, keywords can not contain ` !, ', (, ), and *`.

Reference implementation is taken from [MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).

Test case supplied.