### PR TITLE
Add request option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,17 @@ You can add any [available params](http://docs.aws.amazon.com/AWSECommerceServic
 [browseNodeId:](http://docs.aws.amazon.com/AWSECommerceService/latest/DG/BrowseNodeLookup.html) A positive integer assigned by Amazon that uniquely identifies a product category.
 
 [responseGroup:](http://docs.aws.amazon.com/AWSECommerceService/latest/DG/CHAP_ResponseGroupsList.html) You can use multiple values by separating them with comma (e.g responseGroup: 'MostGifted,NewReleases,MostWishedFor,TopSellers'). Defaults to 'BrowseNodeInfo'
+
+### Passing a custom `request`
+
+You can pass a custom `request` function to be used, for example if you are throttling requests.
+
+```javascript
+var request = require('request');
+var throttledRequest = require('throttled-request')(request);
+
+client.itemSearch({
+  request: throttledRequest
+  // ...
+});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var runQuery = function (credentials, method) {
     var url = generateQueryString(query, method, credentials);
 
     if (typeof cb === 'function') {
-      request(url, function (err, response, body) {
+      (query.request || request)(url, function (err, response, body) {
 
         if (err) {
           cb(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,10 @@ var runQuery = function (credentials, method) {
 
   return function (query, cb) {
     var url = generateQueryString(query, method, credentials);
+    var req = query.request || request;
 
     if (typeof cb === 'function') {
-      (query.request || request)(url, function (err, response, body) {
+      req(url, function (err, response, body) {
 
         if (err) {
           cb(err);
@@ -61,7 +62,7 @@ var runQuery = function (credentials, method) {
 
     var promise = new Promise(function (resolve, reject) {
 
-      request(url, function (err, response, body) {
+      req(url, function (err, response, body) {
 
         if (err) {
           reject(err);


### PR DESCRIPTION
First of all, thanks for making this module. It works really great.

In my project, I throttle requests from different parts of the system to prevent overloading and being throttled by services like Amazon. For this I use the `throttled-request` module. This pull request makes it easy to pass a custom `request` function to be used when calling Amazon. This could also be used for using other libraries, as long as they conform to the interface of `request`.

Example:
```javascript
var request = require('request');
var throttledRequest = require('throttled-request')(request);

client.itemSearch({
  request: throttledRequest
  // ...
});
```
Thanks,
Lasse