### PR TITLE
Remove request from query string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,9 @@ var generateQueryString = require('./utils').generateQueryString,
 var runQuery = function (credentials, method) {
 
   return function (query, cb) {
-    var url = generateQueryString(query, method, credentials);
     var req = query.request || request;
+    delete query.request;
+    var url = generateQueryString(query, method, credentials);
 
     if (typeof cb === 'function') {
       req(url, function (err, response, body) {


### PR DESCRIPTION
I just saw that `request` was passed on to the query string as `Request=`. This of course isn't the way it should work, so this pull request removes `request` from the query before it gets converted to a string. Sorry for not seeing this initially!