### PR TITLE
Make `response` return the whole Items/BrowseNodes array (supports batch requests)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ var runQuery = function (credentials, method) {
                   cb(
                     null,
                     respObj.Items[0].Item,
-                    respObj.Items[0]
+                    respObj.Items
                   );
                 }
               } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0) {
@@ -49,7 +49,7 @@ var runQuery = function (credentials, method) {
                   cb(
                     null,
                     respObj.BrowseNodes[0].BrowseNode,
-                    respObj.BrowseNodes[0]
+                    respObj.BrowseNodes
                   );
                 }
               }


### PR DESCRIPTION
The`response` callback parameter (e.g. `client.itemSearch(query, function(err, result, response) {})` currently assumes that there is only one `Items`/`BrowseNodes` object in the response and returns `respObj.Items[0]` or `respObj.BrowseNodes[0]`.

This is true for normal requests but the Amazon PA API also supports [Batch Requests](http://docs.aws.amazon.com/AWSECommerceService/latest/DG/BatchandMultipleOperationRequests.html) where you can have a second `Items`/`BrowseNodes` object in `respObj.Items[1]` or `respObj.BrowseNodes[1]`, which is never returned.

This PR simply returns the parent `Items`/`BrowseNodes` array in the `response` parameter. It shouldn't break compatibility for most users as this parameter is currently not documented.