### PR TITLE
Update utils.js to support define awsTag in query

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,7 +82,8 @@ var formatQueryParams = function (query, method, credentials) {
 
   // Common params
   params['AWSAccessKeyId'] = credentials.awsId;
-  params['AssociateTag'] = credentials.awsTag;
+  // awsTag is associated with domain, so it ought to be defineable in query.
+  params['AssociateTag'] = query.awsTag || credentials.awsTag;
   params['Timestamp'] = new Date().toISOString();
   params['Service'] = 'AWSECommerceService';
   params['Operation'] = method;


### PR DESCRIPTION
awsTag is associated with domain, so it ought to be defineable in query.