### PR TITLE
"Condition: 'All'" should not be a default option.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ var formatQueryParams = function (query, method, credentials) {
     // Default
     params = setDefaultParams(params, {
       SearchIndex: 'All',
-      Condition: 'All',
+      // Condition: 'All',
       ResponseGroup: 'ItemAttributes',
       Keywords: '',
       ItemPage: '1'
@@ -52,7 +52,7 @@ var formatQueryParams = function (query, method, credentials) {
     // Default
     params = setDefaultParams(params, {
       SearchIndex: 'All',
-      Condition: 'All',
+      // Condition: 'All',
       ResponseGroup: 'ItemAttributes',
       IdType: 'ASIN',
       IncludeReviewsSummary: 'True',


### PR DESCRIPTION
if Condition is all, then item.Offers[0].Price will be a lowest price.
if Condition is not set, item.Offers[0].Price will be amazon main price.
Condition is not required option, I think the implements of scratchpad is right.
(ref: http://webservices.amazon.com/scratchpad/index.html )