### PR TITLE
Upgrade request to ^2.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "es6-promise": "^3.0.2",
-    "request": "^2.79.0",
+    "request": "^2.81.0",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {


### PR DESCRIPTION
While running unit tests this warning generates a lot of noise:

```
warning amazon-product-api > request > node-uuid@1.4.8: Use uuid module instead
```

`request ^2.81.0` uses `uuid ^3.0.0` instead of `node-uuid`, alleviating the issue.