### PR TITLE
Re-add support for multiple Items/BrowseNodes arrays in batch requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,58 +27,96 @@ var runQuery = function fnRunQuery(credentials, method) {
 
       req(url, function performRequest(err, response, body) {
         if (err) {
-          failure(err);
-        } else if (!response) {
-          failure('No response (check internet connection)');
-        } else if (response.statusCode !== 200) {
-          parseXML(body, function parseXMLcb(error, resp) {
-            if (error) {
-              failure(error);
-            } else {
-              failure(resp[method + 'ErrorResponse']);
-            }
-          });
-        } else {
-          parseXML(body, function parseXMLcb(error, resp) {
-            var respObj = resp[method + 'Response'];
+          return failure(err);
+        }
 
+        if (!response) {
+          return failure('No response (check internet connection)');
+        }
+
+        if (response.statusCode !== 200) {
+          return parseXML(body, function parseXMLcb(error, resp) {
             if (error) {
-              failure(error);
+              return failure(error);
             }
-            if (respObj.Items && respObj.Items.length > 0) {
-              // Request Error
-              if (respObj.Items[0].Request &&
-                  respObj.Items[0].Request.length > 0 &&
-                  respObj.Items[0].Request[0].Errors) {
-                failure(respObj.Items[0].Request[0].Errors);
-              } else if (respObj.Items[0].Item) {
-                if (resp.ItemSearchResponse) {
-                  success({
-                    response: resp.ItemSearchResponse.Items[0],
-                    results: respObj.Items[0].Item
-                  });
-                } else if (resp.ItemLookupResponse) {
-                  success({
-                    response: resp.ItemLookupResponse.Items[0],
-                    results: respObj.Items[0].Item
-                  });
-                }
-              }
-            } else if (respObj.BrowseNodes && respObj.BrowseNodes.length > 0) {
-              // Request Error
-              if (respObj.BrowseNodes[0].Request &&
-                respObj.BrowseNodes[0].Request.length > 0 &&
-                respObj.BrowseNodes[0].Request[0].Errors) {
-                failure(respObj.BrowseNodes[0].Request[0].Errors);
-              } else if (respObj.BrowseNodes[0].BrowseNode) {
-                success({
-                  response: resp.BrowseNodeLookupResponse.BrowseNodes[0],
-                  results: respObj.BrowseNodes[0].BrowseNode
-                });
-              }
-            }
+            return failure(resp[method + 'ErrorResponse']);
           });
         }
+
+        return parseXML(body, function parseXMLcb(error, resp) {
+          var respObj = resp[method + 'Response'];
+          var Errors = [];
+          var Items = [];
+          var BrowseNodes = [];
+
+          if (error) {
+            return failure(error);
+          }
+
+          if (!respObj) {
+            return failure('No response object');
+          }
+
+          if (respObj.Items && respObj.Items.length) {
+            if (respObj.Items[0] && respObj.Items[0].Request
+              && respObj.Items[0].Request.length && respObj.Items[0].Request[0].Errors) {
+              Errors = Errors.concat(respObj.Items[0].Request[0].Errors);
+            }
+
+            if (respObj.Items[1] && respObj.Items[1].Request &&
+              respObj.Items[1].Request.length && respObj.Items[1].Request[0].Errors) {
+              Errors = Errors.concat(respObj.Items[1].Request[0].Errors);
+            }
+
+            // Request Error
+            if (Errors.length) {
+              return failure(Errors);
+            }
+
+            if (respObj.Items[0] && respObj.Items[0].Item) {
+              Items = Items.concat(respObj.Items[0].Item);
+            }
+
+            if (respObj.Items[1] && respObj.Items[1].Item) {
+              Items = Items.concat(respObj.Items[1].Item);
+            }
+
+            return success({
+              response: respObj.Items,
+              results: Items
+            });
+          } else if (respObj.BrowseNodes && respObj.BrowseNodes.length) {
+            if (respObj.BrowseNodes[0] && respObj.BrowseNodes[0].Request &&
+            respObj.BrowseNodes[0].Request.length && respObj.BrowseNodes[0].Request[0].Errors) {
+              Errors = Errors.concat(respObj.BrowseNodes[0].Request[0].Errors);
+            }
+
+            if (respObj.BrowseNodes[1] && respObj.BrowseNodes[1].Request &&
+            respObj.BrowseNodes[1].Request.length && respObj.BrowseNodes[1].Request[0].Errors) {
+              Errors = Errors.concat(respObj.BrowseNodes[1].Request[0].Errors);
+            }
+
+            // Request Error
+            if (Errors.length) {
+              return failure(Errors);
+            }
+
+            if (respObj.BrowseNodes[0] && respObj.BrowseNodes[0].Item) {
+              BrowseNodes = BrowseNodes.concat(respObj.BrowseNodes[0].Item);
+            }
+
+            if (respObj.BrowseNodes[1] && respObj.BrowseNodes[1].Item) {
+              BrowseNodes = BrowseNodes.concat(respObj.BrowseNodes[1].Item);
+            }
+
+            return success({
+              response: respObj.BrowseNodes,
+              results: BrowseNodes
+            });
+          }
+
+          return failure('No Items or BrowseNodes in response object');
+        });
       });
     });
 


### PR DESCRIPTION
This PR re-adds support for batch requests, merged in master in #53:

The new `results: { response, results }` return object currently assumes that there is only one `Items`/`BrowseNodes` object in the response and returns `respObj.Items[0]` or `respObj.BrowseNodes[0]`.

This is true for normal requests, however the Amazon PA API also supports [Batch Requests](http://docs.aws.amazon.com/AWSECommerceService/latest/DG/BatchandMultipleOperationRequests.html) where you can have a second `Items`/`BrowseNodes` object in `respObj.Items[1]` or `respObj.BrowseNodes[1]`, which are currently never returned.

This PR returns the parent `Items`/`BrowseNodes` array in the `response` property (breaking change), and the combined `Item`/`BrowseNode` array in the `results` property (non-breaking change).

Since the API is being reworked in v1.0, now is a great time to get this fixed once and for all future versions. All tests and linters are passing.