### PR TITLE
Do not include custom request in the URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,10 @@ var Promise = require('es6-promise').Promise;
 var runQuery = function fnRunQuery(credentials, method) {
   return function queryRun(query, cb) {
     var req = query.request || request;
+
+    // Remove request property
+    query.request = undefined;
+
     var url = generateQueryString(query, method, credentials);
 
     var p = new Promise(function queryPromise(resolve, reject) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ function formatQueryParams(query, method, credentials) {
 
   // format query keys
   for (param in query) { // eslint-disable-line no-restricted-syntax
-    if (Object.prototype.hasOwnProperty.call(query, param)) {
+    if (Object.prototype.hasOwnProperty.call(query, param) && query[param] !== undefined) {
       capitalized = capitalize(param);
       params[capitalized] = query[param];
     }


### PR DESCRIPTION
Hello everyone!

I send this PR to avoid encoding the request custom function (if any) into the URL parameters.

I have seen that if we include any custom request function, it will end up being encoded in the URL like this: `&Request=function%20request%28uri%2C%20options%2C%20callback%29%20%7B%0A%20%20if%20%28typeof%20uri%20%3D%3D%3D%20%27undefined%27%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%27undefined%20is%20not%20a%20valid%20uri%20or%20options%20object.%27%29%0A%20%20%7D%0A%0A%20%20var%20params%20%3D%20initParams%28uri%2C%20options%2C%20callback%29%0A%0A%20%20if%20%28params.method%20%3D%3D%3D%20%27HEAD%27%20%26%26%20paramsHaveRequestBody%28params%29%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%27HTTP%20HEAD%20requests%20MUST%20NOT%20include%20a%20request%20body.%27%29%0A%20%20%7D%0A%0A%20%20return%20new%20request.Request%28params%29%0A%7D` 

I saw that in the master branch there were a delete statement to remove it out from query parameters, but it is gone right now.

[Adding a delete statement to delete an object property is not as performant as setting it to `undefined`](https://github.com/davidmarkclements/v8-perf#removing-properties-from-objects). So what I did is to set it to undefined, and then check if each query parameter is not undefined before assigning it to URL parameters, encoding only the needed parameters in the URL.

I hope there is no major issue with it. If you have any concern or improvement about it, please tell me :)